### PR TITLE
Update https-drill-setup.md

### DIFF
--- a/https-drill-setup.md
+++ b/https-drill-setup.md
@@ -23,7 +23,8 @@ For example, full docker-compose file looks like:
 version: '3'
 
 services:
-ssl-proxy-admin:
+
+  ssl-proxy-admin:
     image: drill4j/ssl-proxy:0.1.0
     ports:
       - 8443:8443
@@ -34,7 +35,7 @@ ssl-proxy-admin:
       TARGET_PORT: 8080
     networks:
           - drill4j-dev-network
-
+          
   drill-admin:
     image: drill4j/admin:0.6.0
     environment:


### PR DESCRIPTION
Corrects the **formatting** for _docker-compose_ file with valid yaml syntax for https setup