### PR TITLE
Use absolute path instead of relative for one-time-setup.mdx

### DIFF
--- a/docs/drill4net/ci-cd-integration.mdx
+++ b/docs/drill4net/ci-cd-integration.mdx
@@ -25,7 +25,7 @@ After each build, you should <Link to="./drill4net-apps#4-usage" target="_blank"
 *application under test* assembly.
 
 ### 3. Run Drill4Net Injector
-After each build, you should <Link to="./drill4net-apps#4-usage" target="_blank">run Drill4Net Injector</Link> for
+After each build, you should <Link to="./drill4net-apps#4-usage-1" target="_blank">run Drill4Net Injector</Link> for
 *assembly with tests*.
 
 ### 4. Run Tests

--- a/docs/drill4net/one-time-setup.mdx
+++ b/docs/drill4net/one-time-setup.mdx
@@ -10,15 +10,15 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 This page describes one time setup steps to start using Drill4Net to minimize your regression suite.
-Once you performed these steps, you can move forward with <Link to="./quick-start-guide" target="_blank">quick start guide</Link>
-or <Link to="./ci-cd-integration" target="_blank">CI/CD integration</Link>.
+Once you performed these steps, you can move forward with <Link to="/docs/drill4net/quick-start-guide" target="_blank">quick start guide</Link>
+or <Link to="/docs/drill4net/ci-cd-integration" target="_blank">CI/CD integration</Link>.
 
 ## 1. Install Drill4J Admin
-First of all you need to install *Drill4J Admin*. Use <Link to="./drill4j-admin-installation" target="_blank">this guide</Link>
+First of all you need to install *Drill4J Admin*. Use <Link to="/docs/drill4net/drill4j-admin-installation" target="_blank">this guide</Link>
 to install *Drill4J Admin*.
 
 ## 2. Configure Drill4Net Scanner
-Download and configure *Drill4Net Scanner* as described <Link to="./drill4net-apps#drill4net-scanner" target="_blank">here</Link>.
+Download and configure *Drill4Net Scanner* as described <Link to="/docs/drill4net/drill4net-apps#drill4net-scanner" target="_blank">here</Link>.
 
 <Info>
   NOTE <br/>
@@ -27,10 +27,10 @@ Download and configure *Drill4Net Scanner* as described <Link to="./drill4net-ap
 </Info>
 
 ## 3. Configure Drill4Net Injector
-Download and configure *Drill4Net Injector* as described <Link to="./drill4net-apps#drill4net-injector" target="_blank">here</Link>.
+Download and configure *Drill4Net Injector* as described <Link to="/docs/drill4net/drill4net-apps#drill4net-injector" target="_blank">here</Link>.
 
 ## 4. Setup Application Under Test
-Setup your application under test as described <Link to="./app-under-test-setup" target="_blank">here</Link>.
+Setup your application under test as described <Link to="/docs/drill4net/app-under-test-setup" target="_blank">here</Link>.
 
 <Info>
   NOTE <br/>
@@ -39,10 +39,10 @@ Setup your application under test as described <Link to="./app-under-test-setup"
 </Info>
 
 ## 5. Setup Project with Tests
-Setup your project with tests as described <Link to="./tests-project-setup" target="_blank">here</Link>.
+Setup your project with tests as described <Link to="/docs/drill4net/tests-project-setup" target="_blank">here</Link>.
 
 ## 6. Run Drill4Net Scanner
-After *application under test* build is finished, run Drill4Net Scanner as described <Link to="./drill4net-apps#4-usage" target="_blank">here</Link>.
+After *application under test* build is finished, run Drill4Net Scanner as described <Link to="/docs/drill4net/drill4net-apps#4-usage" target="_blank">here</Link>.
 
 <Info>
   NOTE <br/>


### PR DESCRIPTION
`one-time-setup.mdx` is not included in `sidebars.js` and is simply referenced from other pages.
For some reason, when I create link on `one-time-setup.mdx` relative link path is resolved differently on local environment and deployed drill4j.github.io. Example:
```
<Link to="./quick-start-guide" target="_blank">quick start guide</Link>
```
will result in:
`http://localhost:3000/docs/drill4net/quick-start-guide` on local environment which is fine
`https://drill4j.github.io/docs/drill4net/one-time-setup/quick-start-guide` on deployed site, which is incorrect (*one-time-setup* part is extra).

I decided to use absolute path like `/docs/drill4net/quick-start-guide` instead of `./quick-start-guide`