### PR TITLE
docs: update to ui 0.1.2

### DIFF
--- a/static/files/0.9.0/deploy-drill4j-services/drill.env
+++ b/static/files/0.9.0/deploy-drill4j-services/drill.env
@@ -1,5 +1,5 @@
 DRILL_ADMIN_BACKEND_VERSION=0.9.3
-DRILL_UI_VERSION=0.1.1
+DRILL_UI_VERSION=0.1.2
 DRILL_ADMIN_BACKEND_DB_MAX_POOL_SIZE=50
 
 # Points to Metabase UI instance. "http://localhost:8095" value is only fitting for the local deployment. Make sure to set to the appropriate host name

--- a/static/files/0.9.0/versions.json
+++ b/static/files/0.9.0/versions.json
@@ -3,6 +3,6 @@
     "testAgent": "0.23.3",
     "cicdPlugin": "0.1.6",
     "adminBackend": "0.9.3",
-    "ui": "0.1.1",
+    "ui": "0.1.2",
     "metabaseDashboards": "v20"
 }


### PR DESCRIPTION
added `BASE_PATH` env variable to allow serving UI from both root and `/path`