### PR TITLE
feat: add logging retention policies for `drill-admin`, `postgres`

### DIFF
--- a/static/files/0.9.0/deploy-drill4j-services/docker-compose.yml
+++ b/static/files/0.9.0/deploy-drill4j-services/docker-compose.yml
@@ -29,6 +29,11 @@ services:
       interval: 10s
       timeout: 3s
       retries: 30
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "5"
     ports:
       - 8090:8090
     depends_on:
@@ -37,6 +42,7 @@ services:
 
   postgres:
     image: postgres:17.0
+    shm_size: 1g
     ports:
       - '5432:5432'
     environment:
@@ -54,6 +60,11 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "5"
     command: ["postgres", "-c", "log_statement=all", "-c", "log_min_duration_statement=0"]
 
   metabase:


### PR DESCRIPTION
fix: extend `shm_size` for `postgres` to avoid errors when allocating shared memory